### PR TITLE
Bruker support, LICENSE fix, README fix

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -3,7 +3,7 @@ All rights reserved.
 
 1.  Battelle Memorial Institute (hereinafter Battelle) hereby grants
 permission to any person or entity lawfully obtaining a copy of this software
-and associated documentation files (hereinafter “the Software”) to
+and associated documentation files (hereinafter "the Software") to
 redistribute and use the Software in source and binary forms, with or without
 modification. Such person or entity may use, copy, modify, merge, publish,
 distribute, sublicense, and/or sell copies of the Software, and may permit

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To read input data, ``nmrfit`` relies on the [``nmrglue``](https://www.nmrglue.c
 import nmrfit
 
 # read in data
-nmrfit.load('fid', 'propcar')
+data = nmrfit.load('fid', 'propcar')
 ```
 In many cases, the signal of interest comprises only a subsection of the captured spectrum.  To restrict the fitting algorithm to only the pertinent part of the signal, the method ``get_bounds()`` is used to bound the data with respect to frequency.  The lower and upper bounds may be passed as arguments, or no arguments may be passed to prompt the user to interactively select the bounds by clicking twice on a displayed plot of the data.  To prepare for subsequent steps, nmrglue package is again used to perform an initial, approximate phase correction (initial phase correction is later refined by the fitting process).
 
@@ -63,7 +63,7 @@ Once the optimizer converges, the ``FitUtility`` method ``generate_result()`` ge
 
 ```python
 # perform the fit
-fit = nmrft.fit(data, lb, ub)
+fit = nmrfit.fit(data, lb, ub)
 
 # generate results
 fit.generate_result(scale=1)


### PR DESCRIPTION
Bruker support added by modifying _core.py to allow vendor declaration. The input data folder location has been genericised, so old scripts may need to be updated. 
//
The quotation marks in the LICENSE file, along with the undefined encoding in the setup.py file, made the install procedure fail with Python 3.7/pip 19.3.1. Quote marks changed to unicode compatible ones. 
Alternatively, the setup.py file could be fixed by changing:
`with open('LICENSE') as f:
`
to 

`with open('LICENSE', encoding='utf-8') as f:`
//
README fix for a few minor typos/omissions